### PR TITLE
refactor(auth): rename (auth) route group to /auth segment

### DIFF
--- a/frontend/src/app/account/AccountContent.tsx
+++ b/frontend/src/app/account/AccountContent.tsx
@@ -75,7 +75,7 @@ export function AccountContent() {
         const loadData = async () => {
             const { data: { user: authUser } } = await supabase.auth.getUser()
             if (!authUser) {
-                router.push("/login")
+                router.push("/auth/login")
                 return
             }
             setUser(authUser)
@@ -170,7 +170,7 @@ export function AccountContent() {
 
     const handleSignOut = async () => {
         await supabase.auth.signOut()
-        router.push("/login")
+        router.push("/auth/login")
     }
 
     if (loading || !user) {

--- a/frontend/src/app/account/reset-password/page.tsx
+++ b/frontend/src/app/account/reset-password/page.tsx
@@ -70,7 +70,7 @@ export default function ResetPasswordPage() {
                 toast.success("Security credentials updated successfully.")
                 // Sign out after reset to ensure clean state or redirect to login
                 await supabase.auth.signOut()
-                router.push("/login?message=password-updated")
+                router.push("/auth/login?message=password-updated")
             }
         } catch (err) {
             toast.error("An unexpected error occurred.")
@@ -98,10 +98,10 @@ export default function ResetPasswordPage() {
                     <h1 className="font-serif text-3xl text-soft-black">Session Expired</h1>
                     <p className="text-taupe font-serif italic text-lg">Your security window has closed or the link is invalid. Please request a new link.</p>
                     <div className="flex flex-col gap-4 pt-4">
-                        <Link href="/forgot-password" className="inline-block bg-brand text-white px-10 py-4 rounded-2xl font-black text-[10px] uppercase tracking-[0.3em] shadow-xl shadow-brand/20 transition-all hover:-translate-y-1">
+                        <Link href="/auth/forgot-password" className="inline-block bg-brand text-white px-10 py-4 rounded-2xl font-black text-[10px] uppercase tracking-[0.3em] shadow-xl shadow-brand/20 transition-all hover:-translate-y-1">
                             Request New Link
                         </Link>
-                        <Link href="/login" className="text-taupe hover:text-brand text-[10px] font-black uppercase tracking-[0.2em] transition-colors">
+                        <Link href="/auth/login" className="text-taupe hover:text-brand text-[10px] font-black uppercase tracking-[0.2em] transition-colors">
                             Return to Login
                         </Link>
                     </div>
@@ -181,7 +181,7 @@ export default function ResetPasswordPage() {
                         </form>
 
                         <footer className="mt-10 text-center border-t border-stone-beige/20 pt-8">
-                            <Link href="/login" className="text-taupe hover:text-brand text-[10px] font-black uppercase tracking-[0.2em] flex items-center justify-center gap-2 transition-colors">
+                            <Link href="/auth/login" className="text-taupe hover:text-brand text-[10px] font-black uppercase tracking-[0.2em] flex items-center justify-center gap-2 transition-colors">
                                 <ArrowLeft className="w-3 h-3" /> Back to Login
                             </Link>
                         </footer>

--- a/frontend/src/app/auth/create-account/page.tsx
+++ b/frontend/src/app/auth/create-account/page.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useState } from "react"
+import { createClient } from "@/utils/supabase/client"
+import { useRouter, useSearchParams } from "next/navigation"
+import Link from "next/link"
+import { Loader2, Mail, Lock, User, Eye, EyeOff } from "lucide-react"
+import { toast } from "sonner"
+
+/**
+ * Create account page — email/password signup with name field.
+ * After signup, user receives verification email from Supabase.
+ */
+export default function CreateAccountPage() {
+    const [name, setName] = useState("")
+    const [email, setEmail] = useState("")
+    const [password, setPassword] = useState("")
+    const [confirmPassword, setConfirmPassword] = useState("")
+    const [showPassword, setShowPassword] = useState(false)
+    const [loading, setLoading] = useState(false)
+    const [oauthLoading, setOauthLoading] = useState(false)
+
+    const supabase = createClient()
+    const router = useRouter()
+    const searchParams = useSearchParams()
+    const redirectTo = searchParams.get("redirect") || "/"
+
+    const handleSignup = async (e: React.FormEvent) => {
+        e.preventDefault()
+
+        if (password !== confirmPassword) {
+            toast.error("Passwords do not match")
+            return
+        }
+        if (password.length < 6) {
+            toast.error("Password must be at least 6 characters")
+            return
+        }
+
+        setLoading(true)
+        try {
+            const { error } = await supabase.auth.signUp({
+                email,
+                password,
+                options: {
+                    data: { full_name: name },
+                    emailRedirectTo: `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(redirectTo)}`,
+                },
+            })
+            if (error) {
+                toast.error(error.message)
+            } else {
+                router.push("/auth/login?message=account-created")
+            }
+        } catch {
+            toast.error("Something went wrong. Please try again.")
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    const handleGoogleSignup = async () => {
+        setOauthLoading(true)
+        const { error } = await supabase.auth.signInWithOAuth({
+            provider: "google",
+            options: {
+                redirectTo: `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(redirectTo)}`,
+            },
+        })
+        if (error) {
+            toast.error(error.message)
+            setOauthLoading(false)
+        }
+    }
+
+    return (
+        <div className="bg-white dark:bg-surface-dark rounded-3xl p-8 md:p-10 border border-brand/10 shadow-xl shadow-brand/5">
+            <div className="text-center mb-8">
+                <h1 className="font-serif text-3xl text-soft-black dark:text-white mb-2">Create Account</h1>
+                <p className="text-taupe text-sm">Join our community of food lovers</p>
+            </div>
+
+            {/* Google OAuth */}
+            <button
+                onClick={handleGoogleSignup}
+                disabled={oauthLoading}
+                className="w-full flex items-center justify-center gap-3 py-3 rounded-xl border border-stone-beige/40 hover:border-brand/30 hover:bg-warm-white dark:hover:bg-white/5 transition-all text-sm font-medium text-soft-black dark:text-white disabled:opacity-50"
+            >
+                {oauthLoading ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                    <svg className="w-5 h-5" viewBox="0 0 24 24">
+                        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+                        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+                    </svg>
+                )}
+                Continue with Google
+            </button>
+
+            {/* Divider */}
+            <div className="flex items-center gap-4 my-6">
+                <div className="flex-1 h-px bg-stone-beige/40" />
+                <span className="text-[10px] font-bold uppercase tracking-widest text-taupe">or</span>
+                <div className="flex-1 h-px bg-stone-beige/40" />
+            </div>
+
+            {/* Signup form */}
+            <form onSubmit={handleSignup} className="space-y-4">
+                <div className="space-y-2">
+                    <label className="text-[10px] font-bold uppercase tracking-[0.2em] text-taupe flex items-center gap-2">
+                        <User className="w-3 h-3" /> Full Name
+                    </label>
+                    <input
+                        type="text"
+                        required
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        placeholder="Your full name"
+                        className="w-full bg-warm-white/50 dark:bg-background-dark border border-stone-beige/20 rounded-xl px-4 py-3 text-sm focus:ring-1 focus:ring-brand outline-none transition-all"
+                    />
+                </div>
+                <div className="space-y-2">
+                    <label className="text-[10px] font-bold uppercase tracking-[0.2em] text-taupe flex items-center gap-2">
+                        <Mail className="w-3 h-3" /> Email
+                    </label>
+                    <input
+                        type="email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="you@example.com"
+                        className="w-full bg-warm-white/50 dark:bg-background-dark border border-stone-beige/20 rounded-xl px-4 py-3 text-sm focus:ring-1 focus:ring-brand outline-none transition-all"
+                    />
+                </div>
+                <div className="space-y-2">
+                    <label className="text-[10px] font-bold uppercase tracking-[0.2em] text-taupe flex items-center gap-2">
+                        <Lock className="w-3 h-3" /> Password
+                    </label>
+                    <div className="relative">
+                        <input
+                            type={showPassword ? "text" : "password"}
+                            required
+                            minLength={6}
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            placeholder="Min. 6 characters"
+                            className="w-full bg-warm-white/50 dark:bg-background-dark border border-stone-beige/20 rounded-xl px-4 py-3 pr-11 text-sm focus:ring-1 focus:ring-brand outline-none transition-all"
+                        />
+                        <button
+                            type="button"
+                            onClick={() => setShowPassword(!showPassword)}
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-taupe hover:text-brand transition-colors"
+                        >
+                            {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                        </button>
+                    </div>
+                </div>
+                <div className="space-y-2">
+                    <label className="text-[10px] font-bold uppercase tracking-[0.2em] text-taupe flex items-center gap-2">
+                        <Lock className="w-3 h-3" /> Confirm Password
+                    </label>
+                    <input
+                        type={showPassword ? "text" : "password"}
+                        required
+                        minLength={6}
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        placeholder="Re-enter your password"
+                        className="w-full bg-warm-white/50 dark:bg-background-dark border border-stone-beige/20 rounded-xl px-4 py-3 text-sm focus:ring-1 focus:ring-brand outline-none transition-all"
+                    />
+                </div>
+
+                <button
+                    type="submit"
+                    disabled={loading}
+                    className="w-full bg-brand hover:bg-brand-hover text-white py-3 rounded-xl text-xs font-bold uppercase tracking-widest transition-all flex items-center justify-center gap-2 shadow-lg shadow-brand/20 disabled:opacity-50 mt-2"
+                >
+                    {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Create Account"}
+                </button>
+            </form>
+
+            {/* Login link */}
+            <p className="text-center text-sm text-taupe mt-6">
+                Already have an account?{" "}
+                <Link href={`/auth/login${redirectTo !== "/" ? `?redirect=${encodeURIComponent(redirectTo)}` : ""}`} className="text-brand hover:text-brand-hover font-semibold transition-colors">
+                    Sign in
+                </Link>
+            </p>
+        </div>
+    )
+}

--- a/frontend/src/app/auth/forgot-password/page.tsx
+++ b/frontend/src/app/auth/forgot-password/page.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useState } from "react"
+import { createClient } from "@/utils/supabase/client"
+import Link from "next/link"
+import { Loader2, Mail, ArrowLeft, CheckCircle } from "lucide-react"
+import { toast } from "sonner"
+
+/**
+ * Forgot password page — sends a password reset email via Supabase.
+ * After sending, shows a confirmation message.
+ */
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = useState("")
+    const [loading, setLoading] = useState(false)
+    const [sent, setSent] = useState(false)
+
+    const supabase = createClient()
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setLoading(true)
+        try {
+            const { error } = await supabase.auth.resetPasswordForEmail(email, {
+                redirectTo: `${window.location.origin}/api/auth/callback?next=/account/reset-password`,
+            })
+            if (error) {
+                toast.error(error.message)
+            } else {
+                setSent(true)
+            }
+        } catch {
+            toast.error("Something went wrong. Please try again.")
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    return (
+        <div className="bg-white dark:bg-surface-dark rounded-3xl p-8 md:p-10 border border-brand/10 shadow-xl shadow-brand/5">
+            {sent ? (
+                /* Success state */
+                <div className="text-center py-4">
+                    <div className="w-16 h-16 bg-moss/10 rounded-full flex items-center justify-center mx-auto mb-6">
+                        <CheckCircle className="w-8 h-8 text-moss" />
+                    </div>
+                    <h1 className="font-serif text-2xl text-soft-black dark:text-white mb-3">Check Your Email</h1>
+                    <p className="text-taupe text-sm mb-2">
+                        We&apos;ve sent a password reset link to:
+                    </p>
+                    <p className="text-brand font-medium text-sm mb-6">{email}</p>
+                    <p className="text-taupe text-xs mb-8">
+                        Click the link in the email to reset your password. If you don&apos;t see it, check your spam folder.
+                    </p>
+                    <Link
+                        href="/auth/login"
+                        className="inline-flex items-center gap-2 text-brand hover:text-brand-hover text-sm font-semibold transition-colors"
+                    >
+                        <ArrowLeft className="w-4 h-4" /> Back to Sign In
+                    </Link>
+                </div>
+            ) : (
+                /* Form state */
+                <>
+                    <div className="text-center mb-8">
+                        <h1 className="font-serif text-3xl text-soft-black dark:text-white mb-2">Forgot Password</h1>
+                        <p className="text-taupe text-sm">Enter your email and we&apos;ll send you a reset link</p>
+                    </div>
+
+                    <form onSubmit={handleSubmit} className="space-y-4">
+                        <div className="space-y-2">
+                            <label className="text-[10px] font-bold uppercase tracking-[0.2em] text-taupe flex items-center gap-2">
+                                <Mail className="w-3 h-3" /> Email Address
+                            </label>
+                            <input
+                                type="email"
+                                required
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                                placeholder="you@example.com"
+                                className="w-full bg-warm-white/50 dark:bg-background-dark border border-stone-beige/20 rounded-xl px-4 py-3 text-sm focus:ring-1 focus:ring-brand outline-none transition-all"
+                            />
+                        </div>
+
+                        <button
+                            type="submit"
+                            disabled={loading}
+                            className="w-full bg-brand hover:bg-brand-hover text-white py-3 rounded-xl text-xs font-bold uppercase tracking-widest transition-all flex items-center justify-center gap-2 shadow-lg shadow-brand/20 disabled:opacity-50"
+                        >
+                            {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Send Reset Link"}
+                        </button>
+                    </form>
+
+                    <p className="text-center mt-6">
+                        <Link href="/auth/login" className="inline-flex items-center gap-2 text-brand hover:text-brand-hover text-sm font-semibold transition-colors">
+                            <ArrowLeft className="w-4 h-4" /> Back to Sign In
+                        </Link>
+                    </p>
+                </>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/app/auth/layout.tsx
+++ b/frontend/src/app/auth/layout.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link"
+
+/**
+ * Shared layout for auth pages (login, create-account, forgot-password, verify-email).
+ * Centered card layout with brand logo on a minimal background.
+ */
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="min-h-screen bg-ivory dark:bg-background-dark flex flex-col items-center justify-center px-4 py-12">
+            {/* Brand logo */}
+            <Link href="/" className="flex items-center gap-3 mb-10 group">
+                <div className="w-10 h-10 text-brand">
+                    <svg fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+                        <path clipRule="evenodd" d="M24 18.4228L42 11.475V34.3663C42 34.7796 41.7457 35.1504 41.3601 35.2992L24 42V18.4228Z" fill="currentColor" fillRule="evenodd" />
+                        <path clipRule="evenodd" d="M24 8.18819L33.4123 11.574L24 15.2071L14.5877 11.574L24 8.18819ZM9 15.8487L21 20.4805V37.6263L9 32.9945V15.8487ZM27 37.6263V20.4805L39 15.8487V32.9945L27 37.6263ZM25.354 2.29885C24.4788 1.98402 23.5212 1.98402 22.646 2.29885L4.98454 8.65208C3.7939 9.08038 3 10.2097 3 11.475V34.3663C3 36.0196 4.01719 37.5026 5.55962 38.098L22.9197 44.7987C23.6149 45.0671 24.3851 45.0671 25.0803 44.7987L42.4404 38.098C43.9828 37.5026 45 36.0196 45 34.3663V11.475C45 10.2097 44.2061 9.08038 43.0155 8.65208L25.354 2.29885Z" fill="currentColor" fillRule="evenodd" />
+                    </svg>
+                </div>
+                <span className="text-soft-black dark:text-white text-2xl font-black tracking-tighter uppercase group-hover:text-brand transition-colors">
+                    LIKEFOOD
+                </span>
+            </Link>
+
+            {/* Auth card */}
+            <div className="w-full max-w-md">
+                {children}
+            </div>
+
+            {/* Footer */}
+            <p className="mt-10 text-xs text-taupe text-center">
+                &copy; {new Date().getFullYear()} LikeFood. All rights reserved.
+            </p>
+        </div>
+    )
+}

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import { useState } from "react"
+import { createClient } from "@/utils/supabase/client"
+import { useRouter, useSearchParams } from "next/navigation"
+import Link from "next/link"
+import { Loader2, Mail, Lock, Eye, EyeOff } from "lucide-react"
+import { toast } from "sonner"
+
+/**
+ * Login page — email/password + Google OAuth.
+ * Redirects to ?redirect param or "/" after successful login.
+ */
+export default function LoginPage() {
+    const [email, setEmail] = useState("")
+    const [password, setPassword] = useState("")
+    const [showPassword, setShowPassword] = useState(false)
+    const [loading, setLoading] = useState(false)
+    const [oauthLoading, setOauthLoading] = useState(false)
+
+    const supabase = createClient()
+    const router = useRouter()
+    const searchParams = useSearchParams()
+    const redirectTo = searchParams.get("redirect") || "/"
+    const message = searchParams.get("message")
+
+    const handleEmailLogin = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setLoading(true)
+        try {
+            const { error } = await supabase.auth.signInWithPassword({ email, password })
+            if (error) {
+                toast.error(error.message)
+            } else {
+                toast.success("Welcome back!")
+                router.push(redirectTo)
+                router.refresh()
+            }
+        } catch {
+            toast.error("Something went wrong. Please try again.")
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    const handleGoogleLogin = async () => {
+        setOauthLoading(true)
+        const { error } = await supabase.auth.signInWithOAuth({
+            provider: "google",
+            options: {
+                redirectTo: `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(redirectTo)}`,
+            },
+        })
+        if (error) {
+            toast.error(error.message)
+            setOauthLoading(false)
+        }
+    }
+
+    return (
+        <div className="bg-white dark:bg-surface-dark rounded-3xl p-8 md:p-10 border border-brand/10 shadow-xl shadow-brand/5">
+            <div className="text-center mb-8">
+                <h1 className="font-serif text-3xl text-soft-black dark:text-white mb-2">Welcome Back</h1>
+                <p className="text-taupe text-sm">Sign in to continue your culinary journey</p>
+            </div>
+
+            {/* Status messages */}
+            {message === "password-updated" && (
+                <div className="mb-6 p-3 rounded-xl bg-moss/10 border border-moss/20 text-moss text-sm text-center">
+                    Password updated successfully. Please sign in.
+                </div>
+            )}
+            {message === "account-created" && (
+                <div className="mb-6 p-3 rounded-xl bg-moss/10 border border-moss/20 text-moss text-sm text-center">
+                    Account created! Please check your email to verify, then sign in.
+                </div>
+            )}
+
+            {/* Google OAuth */}
+            <button
+                onClick={handleGoogleLogin}
+                disabled={oauthLoading}
+                className="w-full flex items-center justify-center gap-3 py-3 rounded-xl border border-stone-beige/40 hover:border-brand/30 hover:bg-warm-white dark:hover:bg-white/5 transition-all text-sm font-medium text-soft-black dark:text-white disabled:opacity-50"
+            >
+                {oauthLoading ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                    <svg className="w-5 h-5" viewBox="0 0 24 24">
+                        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+                        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+                    </svg>
+                )}
+                Continue with Google
+            </button>
+
+            {/* Divider */}
+            <div className="flex items-center gap-4 my-6">
+                <div className="flex-1 h-px bg-stone-beige/40" />
+                <span className="text-[10px] font-bold uppercase tracking-widest text-taupe">or</span>
+                <div className="flex-1 h-px bg-stone-beige/40" />
+            </div>
+
+            {/* Email/Password form */}
+            <form onSubmit={handleEmailLogin} className="space-y-4">
+                <div className="space-y-2">
+                    <label className="text-[10px] font-bold uppercase tracking-[0.2em] text-taupe flex items-center gap-2">
+                        <Mail className="w-3 h-3" /> Email
+                    </label>
+                    <input
+                        type="email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="you@example.com"
+                        className="w-full bg-warm-white/50 dark:bg-background-dark border border-stone-beige/20 rounded-xl px-4 py-3 text-sm focus:ring-1 focus:ring-brand outline-none transition-all"
+                    />
+                </div>
+                <div className="space-y-2">
+                    <label className="text-[10px] font-bold uppercase tracking-[0.2em] text-taupe flex items-center gap-2">
+                        <Lock className="w-3 h-3" /> Password
+                    </label>
+                    <div className="relative">
+                        <input
+                            type={showPassword ? "text" : "password"}
+                            required
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            placeholder="Enter your password"
+                            className="w-full bg-warm-white/50 dark:bg-background-dark border border-stone-beige/20 rounded-xl px-4 py-3 pr-11 text-sm focus:ring-1 focus:ring-brand outline-none transition-all"
+                        />
+                        <button
+                            type="button"
+                            onClick={() => setShowPassword(!showPassword)}
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-taupe hover:text-brand transition-colors"
+                        >
+                            {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                        </button>
+                    </div>
+                </div>
+
+                <div className="flex justify-end">
+                    <Link href="/auth/forgot-password" className="text-xs text-brand hover:text-brand-hover font-medium transition-colors">
+                        Forgot password?
+                    </Link>
+                </div>
+
+                <button
+                    type="submit"
+                    disabled={loading}
+                    className="w-full bg-brand hover:bg-brand-hover text-white py-3 rounded-xl text-xs font-bold uppercase tracking-widest transition-all flex items-center justify-center gap-2 shadow-lg shadow-brand/20 disabled:opacity-50"
+                >
+                    {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Sign In"}
+                </button>
+            </form>
+
+            {/* Create account link */}
+            <p className="text-center text-sm text-taupe mt-6">
+                Don&apos;t have an account?{" "}
+                <Link href={`/auth/create-account${redirectTo !== "/" ? `?redirect=${encodeURIComponent(redirectTo)}` : ""}`} className="text-brand hover:text-brand-hover font-semibold transition-colors">
+                    Create one
+                </Link>
+            </p>
+        </div>
+    )
+}

--- a/frontend/src/app/auth/verify-email/page.tsx
+++ b/frontend/src/app/auth/verify-email/page.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+import { Mail, ArrowLeft, CheckCircle, XCircle } from "lucide-react"
+
+/**
+ * Email verification landing page.
+ * Shown after user clicks verify link from email.
+ * Displays success or error based on query params.
+ */
+export default function VerifyEmailPage() {
+    const searchParams = useSearchParams()
+    const status = searchParams.get("status") // "success" | "error"
+    const isError = status === "error"
+
+    return (
+        <div className="bg-white dark:bg-surface-dark rounded-3xl p-8 md:p-10 border border-brand/10 shadow-xl shadow-brand/5">
+            <div className="text-center py-4">
+                {isError ? (
+                    <>
+                        <div className="w-16 h-16 bg-red-50 dark:bg-red-950/20 rounded-full flex items-center justify-center mx-auto mb-6">
+                            <XCircle className="w-8 h-8 text-red-500" />
+                        </div>
+                        <h1 className="font-serif text-2xl text-soft-black dark:text-white mb-3">Verification Failed</h1>
+                        <p className="text-taupe text-sm mb-8">
+                            The verification link may have expired or is invalid. Please try signing up again or contact support.
+                        </p>
+                    </>
+                ) : status === "success" ? (
+                    <>
+                        <div className="w-16 h-16 bg-moss/10 rounded-full flex items-center justify-center mx-auto mb-6">
+                            <CheckCircle className="w-8 h-8 text-moss" />
+                        </div>
+                        <h1 className="font-serif text-2xl text-soft-black dark:text-white mb-3">Email Verified!</h1>
+                        <p className="text-taupe text-sm mb-8">
+                            Your email has been verified. You can now sign in to your account.
+                        </p>
+                    </>
+                ) : (
+                    <>
+                        <div className="w-16 h-16 bg-brand/10 rounded-full flex items-center justify-center mx-auto mb-6">
+                            <Mail className="w-8 h-8 text-brand" />
+                        </div>
+                        <h1 className="font-serif text-2xl text-soft-black dark:text-white mb-3">Check Your Email</h1>
+                        <p className="text-taupe text-sm mb-8">
+                            We&apos;ve sent a verification link to your email address. Please click the link to verify your account.
+                        </p>
+                    </>
+                )}
+
+                <Link
+                    href="/auth/login"
+                    className="inline-flex items-center gap-2 bg-brand hover:bg-brand-hover text-white py-3 px-8 rounded-xl text-xs font-bold uppercase tracking-widest transition-all shadow-lg shadow-brand/20"
+                >
+                    <ArrowLeft className="w-4 h-4" /> Go to Sign In
+                </Link>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -88,7 +88,7 @@ export default function CheckoutPage() {
                     <section>
                         <div className="flex items-center justify-between mb-8 pb-3 border-b border-brand/10">
                             <h3 className="text-2xl font-serif font-medium text-soft-black dark:text-white italic">Contact Information</h3>
-                            <Link className="text-[10px] font-bold uppercase tracking-[0.2em] text-brand hover:text-brand-hover transition-colors border-b-2 border-brand/10 hover:border-brand pb-1" href="/login?redirect=/checkout">Sign In</Link>
+                            <Link className="text-[10px] font-bold uppercase tracking-[0.2em] text-brand hover:text-brand-hover transition-colors border-b-2 border-brand/10 hover:border-brand pb-1" href="/auth/login?redirect=/checkout">Sign In</Link>
                         </div>
                         <div className="space-y-6">
                             <label className="block">

--- a/frontend/src/components/layout/ClientLayout.tsx
+++ b/frontend/src/components/layout/ClientLayout.tsx
@@ -43,7 +43,7 @@ export function ClientLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-  const isAuthPage = ["/login", "/create-account", "/verify-email", "/forgot-password"].includes(pathname || "");
+  const isAuthPage = ["/auth/login", "/auth/create-account", "/auth/verify-email", "/auth/forgot-password"].includes(pathname || "");
   const isAdminPage = pathname?.startsWith("/admin");
 
   return (

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -203,7 +203,7 @@ export function Header() {
                                 </button>
                             </div>
                         ) : (
-                            <Link href={`/login?redirect=${pathname || ""}`} className="hidden md:flex items-center gap-2 rounded-full h-10 px-6 bg-brand hover:opacity-90 text-white text-sm font-bold transition-all shadow-lg shadow-brand/20" title="Sign In">
+                            <Link href={`/auth/login?redirect=${pathname || ""}`} className="hidden md:flex items-center gap-2 rounded-full h-10 px-6 bg-brand hover:opacity-90 text-white text-sm font-bold transition-all shadow-lg shadow-brand/20" title="Sign In">
                                 Sign In
                             </Link>
                         )}                    </div>
@@ -258,7 +258,7 @@ export function Header() {
                                 </button>
                             </>
                         ) : (
-                            <Link href={`/login?redirect=${pathname || ""}`} onClick={() => setMobileOpen(false)}
+                            <Link href={`/auth/login?redirect=${pathname || ""}`} onClick={() => setMobileOpen(false)}
                                 className="block mx-4 mt-2 text-center py-3 bg-brand hover:bg-brand-hover text-white rounded-xl text-sm font-bold uppercase tracking-wide transition-colors">
                                 Sign In
                             </Link>

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -45,7 +45,7 @@ export async function middleware(request: NextRequest) {
     // Admin routes: require admin role
     if (path.startsWith("/admin")) {
         if (!user) {
-            const url = new URL("/account", request.url);
+            const url = new URL("/auth/login", request.url);
             url.searchParams.set("redirect", path);
             return NextResponse.redirect(url);
         }
@@ -58,7 +58,7 @@ export async function middleware(request: NextRequest) {
     const protectedPaths = ["/checkout", "/orders"];
     const isProtected = protectedPaths.some((p) => path.startsWith(p));
     if (isProtected && !user) {
-        const redirectUrl = new URL("/account", request.url);
+        const redirectUrl = new URL("/auth/login", request.url);
         redirectUrl.searchParams.set("redirect", path);
         return NextResponse.redirect(redirectUrl);
     }


### PR DESCRIPTION
## Summary
- **fix(build):** Remove non-existent `ShoppingFixed` import from `lucide-react` — Vercel build failure
- **refactor(auth):** Rename `(auth)` route group to `/auth` segment — parenthesized folder caused Git tracking issues on Windows, auth pages missing on master (404)

## Changes
- Auth routes: `/auth/login`, `/auth/create-account`, `/auth/forgot-password`, `/auth/verify-email`
- All internal links updated across 12 files

## Test plan
- [x] `next build` passes locally
- [ ] Verify `/auth/login` loads on Vercel
- [ ] Verify auth navigation flows
- [ ] Verify redirect after login (`?redirect=` param)
